### PR TITLE
Fixes #10 By implementing chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,24 @@ AngularJS or jQuery (works with either one or both)
 Unit tests ([Travis CI](https://travis-ci.org/tbosch/autofill-event))
 
   1. `npm install`
-  1. `bower install`
-  1. `npm install karma -g`
-  1. Run tests with jQuery: `karma start test/unit/config/karma-jquery.conf.js`
-  1. Run tests with Angular: `karma start test/unit/config/karma-angular.conf.js`
+  2. `bower install`
+  3. `npm install -g karma-cli`
+  4. Run tests with jQuery: `karma start test/unit/config/karma-jquery.conf.js`
+  5. Run tests with Angular: `karma start test/unit/config/karma-angular.conf.js`
+
+Testing with PhantomJS
+
+  1. `npm install`
+  2. `bower install`
+  3. `npm install karma-cli phantomjs -g`
+  4. `./scripts/run-unit-tests.sh "PhantomJS"
 
 Manual Tests ([live version](http://tbosch.github.io/autofill-event/))
 
   1. `npm install`
-  1. `bower install`
-  1. `scripts/webserver.js`
-  1. open the [manual runner](http://localhost:8000/manual-tests.html) and follow instructions
+  2. `bower install`
+  3. `scripts/webserver.js`
+  4. open the [manual runner](http://localhost:8000/manual-tests.html) and follow instructions
 
 Notes:
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/tbosch/autofill-event.git"
   },
   "devDependencies": {
-    "bower": "~1.2.2",
+    "bower": "~1.3.12",
     "karma": "0.10.*",
     "karma-jasmine": "0.1.5",
     "karma-chrome-launcher": "0.1.2",

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/src/autofill-event.js
+++ b/src/autofill-event.js
@@ -57,6 +57,7 @@
         triggerChangeEvent(el);
       }
     }
+    return this;
   }
 
   function valueMarked(el) {

--- a/test/unit/autofill-eventSpec.js
+++ b/test/unit/autofill-eventSpec.js
@@ -41,7 +41,6 @@ describe('check other inputs when one input fires a blur event', function() {
       input = container.children().eq(0);
     });
 
-
     describe('changes by user via change event', function() {
 
       it('should not fire an extra change event when there was a change event for the element', function() {
@@ -95,6 +94,7 @@ describe('check other inputs when one input fires a blur event', function() {
     });
 
     describe('misc', function() {
+
       it('should not fire for untouched inputs with empty value', function() {
         input.checkAndTriggerAutoFillEvent();
         expect(input[0].changeEventCount).toBeUndefined();
@@ -105,6 +105,11 @@ describe('check other inputs when one input fires a blur event', function() {
         var newInput = container.children().eq(1);
         newInput.checkAndTriggerAutoFillEvent();
         expect(newInput[0].changeEventCount).toBeUndefined();
+      });
+
+      it('should return the prototype chain so that it can be chained', function() {
+        var ret = input.checkAndTriggerAutoFillEvent();
+        expect(ret.checkAndTriggerAutoFillEvent).toBe(input.checkAndTriggerAutoFillEvent);
       });
 
     });


### PR DESCRIPTION
Previously the `checkAndTriggerAutoFillEvent()` method did not return
the jQuery/jqLite instance and therefore was unable to be chained. This
PR aims to fix that by modifying the `checkAndTriggerAutoFillEvent()` to
return `this`.

Also, this PR updates `README.md` on how to run tests using PhantomJS
