### PR TITLE
update on input events

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ That changed value is stored on the element in a private property.
 Compare the current `value` of the element with the remembered value. If it's different,
 trigger a change event.
 
+## Workaround for Chrome (which won't fill the form contents until th euser has interacted with the form)
+
+1. bind a listener for autoFilled event on your element
+``` $el.bind('autoFilled',callback) ```
+2. the callback function will not get called when a form password has been autofilled by Chrome - but Note you still cannot have access to the content of the password until the user has interacted with the form, but you can, at least, make you element respond appropriately to the event (such has by changing the class to your filled style)
+
 
 ## Dependencies
 

--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,6 @@
   ],
   "devDependencies": {
     "jquery": "1.10.2",
-    "angular": "1.2.*"
+    "angular": "1.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   },
   "devDependencies": {
     "bower": "~1.2.2",
+    "connect": "2.12.*",
     "karma": "0.10.*",
-    "karma-jasmine": "0.1.5",
     "karma-chrome-launcher": "0.1.2",
     "karma-firefox-launcher": "0.1.3",
-    "karma-junit-reporter": "0.2.1",
-    "connect": "2.12.*"
+    "karma-jasmine": "^0.1.5",
+    "karma-junit-reporter": "0.2.1"
   },
   "licenses": [
     {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/tbosch/autofill-event.git"
   },
   "devDependencies": {
-    "bower": "~1.2.2",
+    "bower": "~1.3.12",
     "connect": "2.12.*",
     "karma": "0.10.*",
     "karma-chrome-launcher": "0.1.2",

--- a/src/autofill-event.js
+++ b/src/autofill-event.js
@@ -23,6 +23,12 @@
       findParentForm(target).find('input').checkAndTriggerAutoFillEvent();
     }, 20);
   });
+ 
+  addGlobalEventListener('input', function(target) {
+    window.setTimeout(function() {
+      findParentForm(target).find('input').checkAndTriggerAutoFillEvent();
+    }, 20);
+  });
 
   function DOMContentLoadedListener() {
     // mark all values that are present when the DOM is ready.
@@ -56,6 +62,9 @@
         markValue(el);
         triggerChangeEvent(el);
       }
+      if (hasBeenNewlyAutoFilled(el)) {
+        triggerAutoFilledEvent(el);
+      }
     }
   }
 
@@ -78,6 +87,32 @@
 
   function markValue(el) {
     el.$$currentValue = el.value;
+  }
+
+  function hasBeenNewlyAutoFilled(el) {
+    if (!("$$autoFilled" in el)) {
+      el.autoFilled=false;
+    }
+    var autoFilled = false;
+    var selector;
+    if (!el.$$autoFilled) {
+      try {
+        selector = el.parentNode.querySelector(":autofill");
+      } catch (error) {
+        try {
+          selector = el.parentNode.querySelector(":-webkit-autofill");
+        } catch (error) {
+          try {
+            selector = el.parentNode.querySelector(":-moz-autofill");
+          } catch (error) {
+            // ignore
+          }
+        }
+      }
+      autoFilled = Boolean(selector);
+      el.$$autoFilled = autoFilled;
+    }
+    return autoFilled;
   }
 
   function addValueChangeByJsListener(listener) {
@@ -135,6 +170,13 @@
     var doc = window.document;
     var event = doc.createEvent("HTMLEvents");
     event.initEvent("change", true, true);
+    element.dispatchEvent(event);
+  }
+ 
+  function triggerAutoFilledEvent(element) {
+    var doc = window.document;
+    var event = doc.createEvent("HTMLEvents");
+    event.initEvent("autoFilled", true, true);
     element.dispatchEvent(event);
   }
 

--- a/test/unit/testutils.js
+++ b/test/unit/testutils.js
@@ -3,7 +3,8 @@
   window.testutils = {
     $: window.jQuery || window.angular.element,
     triggerBlurEvent: triggerBlurEvent,
-    triggerChangeEvent: triggerChangeEvent
+    triggerChangeEvent: triggerChangeEvent,
+    triggerInputEvent: triggerInputEvent
   };
 
   function triggerBlurEvent(element) {
@@ -12,6 +13,10 @@
 
   function triggerChangeEvent(element) {
     triggerEvent('change', element);
+  }
+
+  function triggerInputEvent(element) {
+    triggerEvent('input',element);
   }
 
   function triggerEvent(name, element) {


### PR DESCRIPTION
Chrome fires input events on autofill for things like username, so listen for these and resync.

Chrome doesn't allow password fields to be read in javascript before user interaction, so look for these and fire an autoFilled event on the element if this has happened.
